### PR TITLE
Fix cached value handling

### DIFF
--- a/projects/ng-rebrickable/package.json
+++ b/projects/ng-rebrickable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ng-rebrickable",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Angular library to work with Rebrickable API",
   "author": "christianopaets",
   "repository": {

--- a/projects/ng-rebrickable/src/lib/features/http/rebrickable-http-client.ts
+++ b/projects/ng-rebrickable/src/lib/features/http/rebrickable-http-client.ts
@@ -21,7 +21,7 @@ export class RebrickableHttpClient {
       return from(cached).pipe(switchMap((res) => (res ? of(res) : this.request<T>(url, params, config))));
     }
     if (cached) {
-      of(cached);
+      return of(cached);
     }
     return this.request(url, params, config);
   }


### PR DESCRIPTION
Closes #5 
Corrected the logic to return the cached value in `rebrickable-http-client.ts`. Updated the package version to 3.0.1 in `package.json` to reflect the bug fix.